### PR TITLE
CVE-2019-9658: Update version on checkstyle library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
 					<dependency>
 						<groupId>com.puppycrawl.tools</groupId>
 						<artifactId>checkstyle</artifactId>
-						<version>8.16</version>
+						<version>8.22</version>
 					</dependency>
 				</dependencies>
 				<configuration>


### PR DESCRIPTION
[CVE-2019-9658 Detail](https://nvd.nist.gov/vuln/detail/CVE-2019-9658)

Checkstyle prior to 8.18 loads external DTDs by default, which can potentially lead to denial of service attacks or the leaking of confidential information.