### PR TITLE
Add new boolean option `noVersionCheck` 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false # faster builds
 
 jdk:
   - openjdk8
-#  - openjdk11 # todo Blocked by https://github.com/kaitai-io/kaitai_struct/issues/483
-#  - oraclejdk11 # todo Blocked by https://github.com/kaitai-io/kaitai_struct/issues/483
+  - openjdk11
+  - oraclejdk11
 
 script:
   - mvn clean verify -P run-its

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ See [kaitai-java-demo](https://github.com/valery1707/kaitai-java-demo).
 | executionTimeout| Long         | 0.1.3 | Timeout for execution operations.<br><br>**Default**: `5000` |
 | fromFileClass   | String       | 0.1.3 | Classname with custom KaitaiStream implementations for static builder `fromFile(...)`|
 | opaqueTypes     | Boolean      | 0.1.3 | Allow use opaque (external) types in ksy. See more in [documentation](http://doc.kaitai.io/user_guide.html#opaque-types).|
+| noVersionCheck  | Boolean      | 0.1.6 | Allow to disable Java version check. For non-Windows only.<br><br>**Default**: `false`       |
 
 ### Useful commands
 

--- a/src/it/it-skip/pom.xml
+++ b/src/it/it-skip/pom.xml
@@ -23,6 +23,7 @@
 				<version>@project.version@</version>
 				<configuration>
 					<skip>true</skip>
+					<noVersionCheck>true</noVersionCheck>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/it/it-source-absent/pom.xml
+++ b/src/it/it-source-absent/pom.xml
@@ -21,6 +21,9 @@
 				<groupId>@project.groupId@</groupId>
 				<artifactId>@project.artifactId@</artifactId>
 				<version>@project.version@</version>
+				<configuration>
+					<noVersionCheck>true</noVersionCheck>
+				</configuration>
 				<executions>
 					<execution>
 						<id>generate</id>

--- a/src/it/it-source-empty/pom.xml
+++ b/src/it/it-source-empty/pom.xml
@@ -21,6 +21,9 @@
 				<groupId>@project.groupId@</groupId>
 				<artifactId>@project.artifactId@</artifactId>
 				<version>@project.version@</version>
+				<configuration>
+					<noVersionCheck>true</noVersionCheck>
+				</configuration>
 				<executions>
 					<execution>
 						<id>generate</id>

--- a/src/it/it-source-excluded/pom.xml
+++ b/src/it/it-source-excluded/pom.xml
@@ -25,6 +25,7 @@
 					<excludes>
 						<exclude>ico.ksy</exclude>
 					</excludes>
+					<noVersionCheck>true</noVersionCheck>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/it/it-source-exist/pom.xml
+++ b/src/it/it-source-exist/pom.xml
@@ -24,6 +24,9 @@
 				<groupId>@project.groupId@</groupId>
 				<artifactId>@project.artifactId@</artifactId>
 				<version>@project.version@</version>
+				<configuration>
+					<noVersionCheck>true</noVersionCheck>
+				</configuration>
 				<executions>
 					<execution>
 						<id>generate</id>

--- a/src/it/it-source-failed/pom.xml
+++ b/src/it/it-source-failed/pom.xml
@@ -24,6 +24,9 @@
 				<groupId>@project.groupId@</groupId>
 				<artifactId>@project.artifactId@</artifactId>
 				<version>@project.version@</version>
+				<configuration>
+					<noVersionCheck>true</noVersionCheck>
+				</configuration>
 				<executions>
 					<execution>
 						<id>generate</id>

--- a/src/it/it-withOption-exactOutput-target-create/pom.xml
+++ b/src/it/it-withOption-exactOutput-target-create/pom.xml
@@ -27,6 +27,7 @@
 				<configuration>
 					<output>${project.build.sourceDirectory}</output>
 					<exactOutput>true</exactOutput>
+					<noVersionCheck>true</noVersionCheck>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/it/it-withOption-exactOutput-target-overwrite/pom.xml
+++ b/src/it/it-withOption-exactOutput-target-overwrite/pom.xml
@@ -27,6 +27,7 @@
 				<configuration>
 					<output>${project.build.sourceDirectory}</output>
 					<exactOutput>true</exactOutput>
+					<noVersionCheck>true</noVersionCheck>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/it/it-withOption-fromFileClass/pom.xml
+++ b/src/it/it-withOption-fromFileClass/pom.xml
@@ -26,6 +26,7 @@
 				<version>@project.version@</version>
 				<configuration>
 					<fromFileClass>name.valery1707.kaitai.it.CustomStream</fromFileClass>
+					<noVersionCheck>true</noVersionCheck>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/it/it-withOption-opaqueTypes/pom.xml
+++ b/src/it/it-withOption-opaqueTypes/pom.xml
@@ -26,6 +26,7 @@
 				<version>@project.version@</version>
 				<configuration>
 					<opaqueTypes>true</opaqueTypes>
+					<noVersionCheck>true</noVersionCheck>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/it/lib-commons-io_24-exist/pom.xml
+++ b/src/it/lib-commons-io_24-exist/pom.xml
@@ -31,6 +31,9 @@
 						<version>2.4</version>
 					</dependency>
 				</dependencies>
+				<configuration>
+					<noVersionCheck>true</noVersionCheck>
+				</configuration>
 				<executions>
 					<execution>
 						<id>generate</id>

--- a/src/it/lib-commons-io_24-failed/pom.xml
+++ b/src/it/lib-commons-io_24-failed/pom.xml
@@ -31,6 +31,9 @@
 						<version>2.4</version>
 					</dependency>
 				</dependencies>
+				<configuration>
+					<noVersionCheck>true</noVersionCheck>
+				</configuration>
 				<executions>
 					<execution>
 						<id>generate</id>

--- a/src/main/java/name/valery1707/kaitai/KaitaiMojo.java
+++ b/src/main/java/name/valery1707/kaitai/KaitaiMojo.java
@@ -157,6 +157,14 @@ public class KaitaiMojo extends AbstractMojo {
 	@Parameter(property = "kaitai.opaqueTypes")
 	private Boolean opaqueTypes;
 
+	/**
+	 * Allow to disable Java version check.
+	 *
+	 * @since 0.1.6
+	 */
+	@Parameter(property = "kaitai.noVersionCheck", defaultValue = "false")
+	private boolean noVersionCheck;
+
 	@Parameter(defaultValue = "${settings}", readonly = true)
 	private Settings settings;
 
@@ -221,6 +229,7 @@ public class KaitaiMojo extends AbstractMojo {
 			.executionTimeout(executionTimeout)
 			.fromFileClass(fromFileClass)
 			.opaqueTypes(opaqueTypes)
+			.noVersionCheck(noVersionCheck)
 			.generate(logger);
 
 		//Add generated directory into Maven's build scope

--- a/src/test/java/name/valery1707/kaitai/KaitaiGeneratorTest.java
+++ b/src/test/java/name/valery1707/kaitai/KaitaiGeneratorTest.java
@@ -59,6 +59,7 @@ public class KaitaiGeneratorTest {
 		Files.createDirectory(generated);
 		return KaitaiGenerator
 			.generator(kaitai, generated, "name.valery1707.kaitai.test")
+			.noVersionCheck(true)
 			.withSource(sources);
 	}
 
@@ -114,7 +115,8 @@ public class KaitaiGeneratorTest {
 				: "/executable/_timeout.sh"
 			, temporaryFolder
 		);
-		return KaitaiGenerator.generator(executable, executable.getParent(), getClass().getPackage().getName());
+		return KaitaiGenerator.generator(executable, executable.getParent(), getClass().getPackage().getName())
+							  .noVersionCheck(true);
 	}
 
 	@Test


### PR DESCRIPTION
Add possibility to skip Java version check. It is necessary to workaround SBT issue about Java version detection. See kaitai-io/kaitai_struct#483
