### PR TITLE
Badge: remove GitHub from sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,3 @@
-github: valery1707
 issuehunt: valery1707
 ko_fi: valery1707
 liberapay: valery1707


### PR DESCRIPTION
GitHub Sponsors not enrolled in Russia yet