### PR TITLE
Add `readPos` and `debug` parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ See [kaitai-java-demo](https://github.com/valery1707/kaitai-java-demo).
 | opaqueTypes     | Boolean      | 0.1.3 | Allow use opaque (external) types in ksy. See more in [documentation](http://doc.kaitai.io/user_guide.html#opaque-types).|
 | noVersionCheck  | Boolean      | 0.1.6 | Allow to disable Java version check. For non-Windows only.<br><br>**Default**: `false`       |
 | noAutoRead      | Boolean      | 0.1.7 | Allow to disable auto-running `_read` in constructor <br><br>**Default**: `false`       |
+| readPos         | boolean      | 0.1.7 | Adds fields `_seqFields`, `_attrStart`, `_attrEnd`, `_arrStart`, and `_arrEnd` to the compiled Java file. Needed for visuzalization tools. <br><br>**Default**: `false` |
+| debug           | boolean      | 0.1.7 | Same as setting both `noAutoRead` and `readPos` to true. <br><br>**Default**: `false`                                                                                   |
 
 ### Useful commands
 

--- a/src/main/java/name/valery1707/kaitai/KaitaiGenerator.java
+++ b/src/main/java/name/valery1707/kaitai/KaitaiGenerator.java
@@ -36,6 +36,8 @@ public class KaitaiGenerator {
 	private Boolean opaqueTypes;
 	private boolean noVersionCheck;
 	private boolean noAutoRead;
+	private boolean readPos;
+	private boolean debug;
 
 	/**
 	 * Build {@code KaitaiGenerator} with preconfigured state.
@@ -274,6 +276,44 @@ public class KaitaiGenerator {
 		return this;
 	}
 
+	public void setReadPos(boolean readPos) {
+		this.readPos = readPos;
+	}
+
+	public boolean isReadPos() {
+		return readPos;
+	}
+
+	/**
+	 * Set readPos mode and return self.
+	 *
+	 * @param readPos new value
+	 * @return self
+	 */
+	public KaitaiGenerator readPos(boolean readPos) {
+		setReadPos(readPos);
+		return this;
+	}
+
+	public void setDebug(boolean debug) {
+		this.debug = debug;
+	}
+
+	public boolean isDebug() {
+		return debug;
+	}
+
+	/**
+	 * Set debug mode and return self.
+	 *
+	 * @param debugMode new value
+	 * @return self
+	 */
+	public KaitaiGenerator debug(boolean debugMode) {
+		setDebug(debugMode);
+		return this;
+	}
+
 
 	private ProcBuilder process(Logger log) {
 		ProcBuilder builder = new ProcBuilder(getKaitai().normalize().toAbsolutePath().toString())
@@ -342,6 +382,12 @@ public class KaitaiGenerator {
 			.withArgs("--java-package", getPackageName());
 		if (isNoAutoRead()) {
 			builder.withArgs("--no-auto-read");
+		}
+		if (isReadPos()) {
+			builder.withArgs("--read-pos");
+		}
+		if (isDebug()) {
+			builder.withArgs("--debug");
 		}
 		if (isNotBlank(getFromFileClass())) {
 			builder.withArgs("--java-from-file-class", getFromFileClass());

--- a/src/main/java/name/valery1707/kaitai/KaitaiMojo.java
+++ b/src/main/java/name/valery1707/kaitai/KaitaiMojo.java
@@ -171,6 +171,22 @@ public class KaitaiMojo extends AbstractMojo {
 	@Parameter(property = "kaitai.noVersionCheck", defaultValue = "false")
 	private boolean noVersionCheck;
 
+	/**
+	 * Adds fields {@code _seqFields}, {@code _attrStart}, {@code _attrEnd}, {@code _arrStart}, and {@code _arrEnd} to the compiled Java file.
+	 *
+	 * @see <a href="https://github.com/kaitai-io/kaitai_struct_compiler/blob/0a04070dd53542c80e22ca07d0c116b9d371d740/jvm/src/main/scala/io/kaitai/struct/JavaMain.scala#L159">kaitai-struct-compiler source</a>
+	 */
+	@Parameter(property = "kaitai.readPos", defaultValue = "false")
+	private boolean readPos;
+
+	/**
+	 * Same as setting both {@code noAutoRead} and {@code readPos} to true.
+	 *
+	 * @see <a href="https://github.com/kaitai-io/kaitai_struct_compiler/blob/0a04070dd53542c80e22ca07d0c116b9d371d740/jvm/src/main/scala/io/kaitai/struct/JavaMain.scala#L163">kaitai-struct-compiler source</a>
+	 */
+	@Parameter(property = "kaitai.debug", defaultValue = "false")
+	private boolean debug;
+
 	@Parameter(defaultValue = "${settings}", readonly = true)
 	private Settings settings;
 
@@ -237,6 +253,8 @@ public class KaitaiMojo extends AbstractMojo {
 			.opaqueTypes(opaqueTypes)
 			.noVersionCheck(noVersionCheck)
 			.noAutoRead(noAutoRead)
+			.readPos(readPos)
+			.debug(debug)
 			.generate(logger);
 
 		//Add generated directory into Maven's build scope


### PR DESCRIPTION
Add two parameters to the plugin:

| Maven plugin parameter | kaitai-struct-compiler option | Description|
| -------------| ---------------|-------------|
| `<readPos>` | `--read-pos` | Allows the `_read` method to save the position where items were read from |
| `<debug>`   | `--debug`     | Same as `--no-auto-read --read-pos` (useful for visualization tools) |

When the `--read-pos` option is given, the compiled Java file will have these extra fields:

```java
String[] _seqFields
Map<String, Integer> _attrStart
Map<String, Integer> _attrEnd
Map<String, ArrayList<Integer>> _arrStart
Map<String, ArrayList<Integer>> _arrEnd
```

I want to use kaitai-maven-plugin in [kaitai_struct_gui](https://github.com/pfroud/kaitai_struct_gui), but the GUI only works on files with the extra debugging fields.

For reference: 

* The `--read-pos` command line option is declared here: [JavaMain.scala#L159](https://github.com/kaitai-io/kaitai_struct_compiler/blob/0a04070dd53542c80e22ca07d0c116b9d371d740/jvm/src/main/scala/io/kaitai/struct/JavaMain.scala#L159)
* The `--debug` command line option is declared here: [JavaMain.scala#L163](https://github.com/kaitai-io/kaitai_struct_compiler/blob/0a04070dd53542c80e22ca07d0c116b9d371d740/jvm/src/main/scala/io/kaitai/struct/JavaMain.scala#L163)
* The `_seqFields` part is added to the output file here: [JavaCompiler.scala#L716](https://github.com/kaitai-io/kaitai_struct_compiler/blob/0a04070dd53542c80e22ca07d0c116b9d371d740/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala#L716)
* The `Map`s are added to the output file here: [JavaCompiler.scala#L78](https://github.com/kaitai-io/kaitai_struct_compiler/blob/0a04070dd53542c80e22ca07d0c116b9d371d740/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala#L78)