### PR TITLE
Change download url. Fixes #53

### DIFF
--- a/src/main/java/name/valery1707/kaitai/KaitaiUtils.java
+++ b/src/main/java/name/valery1707/kaitai/KaitaiUtils.java
@@ -359,7 +359,7 @@ public final class KaitaiUtils {
 		return dir;
 	}
 
-	private static final String URL_FORMAT = "https://dl.bintray.com/kaitai-io/universal/%s/kaitai-struct-compiler-%s.zip";
+	private static final String URL_FORMAT = "https://github.com/kaitai-io/kaitai_struct_compiler/releases/download/%s/kaitai-struct-compiler-%s.zip";
 
 	/**
 	 * Use external {@code url} if it non null or create new url from template.


### PR DESCRIPTION
Use the Github release page for now, as per the Kaitai website:

---------------
## 2021-05-02 — Temporarily using GitHub Releases for compiler distributions

As of May 2, 2021, JFrog Bintray (distribution service where we hosted the compiler artifacts for years) [has been sunset](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), so we moved all stable compiler versions to GitHub Releases [in the kaitai_struct_compiler repository](https://github.com/kaitai-io/kaitai_struct_compiler/releases). The installation commands below have been updated accordingly. Development (unstable) builds that were hosted on Bintray (Linux .deb and Universal .zip) are not available right now (until we set up the new distribution system).

We're currently setting up an alternative repository to replace Bintray, which will be available on a custom domain `packages.kaitai.io` to be future-proof, so stay tuned!

--------------


Note that this also fixes https://github.com/valery1707/kaitai-gradle-plugin/issues/20