### PR TITLE
Support 0.9+ and use 0.10 as the default version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,23 @@ See [kaitai-java-demo](https://github.com/valery1707/kaitai-java-demo).
 
 ## Plugin parameters
 
-| Name            | Type         | Since | Description                                                                                                             |
-|-----------------|--------------|-------|-------------------------------------------------------------------------------------------------------------------------|
-| skip            | boolean      | 0.1.0 | Skip plugin execution (don't read/validate any files, don't generate any java types).<br><br>**Default**: `false`       |
-| url             | java.net.URL | 0.1.0 | Direct link onto [KaiTai universal zip archive](http://kaitai.io/#download).<br><br>**Default**: Detected from version  |
-| version         | String       | 0.1.0 | Version of [KaiTai](http://kaitai.io/#download) library.<br><br>**Default**: `0.8`                                      |
-| cacheDir        | java.io.File | 0.1.0 | Cache directory for download KaiTai library.<br><br>**Default**: `build/tmp/kaitai-cache`                               |
-| sourceDirectory | java.io.File | 0.1.0 | Source directory with [Kaitai Struct language](http://formats.kaitai.io/) files.<br><br>**Default**: src/main/resources/kaitai |
-| includes        | String[]     | 0.1.0 | Include wildcard pattern list.<br><br>**Default**: ["*.ksy"]                                                            |
-| excludes        | String[]     | 0.1.0 | Exclude wildcard pattern list.<br><br>**Default**: []                                                                   |
-| output          | java.io.File | 0.1.0 | Target directory for generated Java source files.<br><br>**Default**: `build/generated/kaitai`                          |
-| exactOutput     | Boolean      | 0.1.5 | Move root of packages directory structure exact inside configured output path and remove `src` item.<br><br>**Default**: `false`|
-| packageName     | String       | 0.1.0 | Target package for generated Java source files.<br><br>**Default**: Trying to get project's group or `kaitai` otherwise |
-| executionTimeout| Long         | 0.1.3 | Timeout for execution operations.<br><br>**Default**: `5000` |
-| fromFileClass   | String       | 0.1.3 | Classname with custom KaitaiStream implementations for static builder `fromFile(...)`|
-| opaqueTypes     | Boolean      | 0.1.3 | Allow use opaque (external) types in ksy. See more in [documentation](http://doc.kaitai.io/user_guide.html#opaque-types).|
-| noVersionCheck  | Boolean      | 0.1.6 | Allow to disable Java version check. For non-Windows only.<br><br>**Default**: `false`       |
-| noAutoRead      | Boolean      | 0.1.7 | Allow to disable auto-running `_read` in constructor <br><br>**Default**: `false`       |
+| Name            | Type         | Since | Description                                                                                                                                                                          |
+|-----------------|--------------|-------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| skip            | boolean      | 0.1.0 | Skip plugin execution (don't read/validate any files, don't generate any java types).<br><br>**Default**: `false`                                                                    |
+| url             | java.net.URL | 0.1.0 | Direct link onto [KaiTai universal zip archive](http://kaitai.io/#download).<br><br>**Default**: Detected from version                                                               |
+| version         | String       | 0.1.0 | Version of [KaiTai](http://kaitai.io/#download) library.<br><br>**Default**: `0.10`                                                                                                  |
+| cacheDir        | java.io.File | 0.1.0 | Cache directory for download KaiTai library.<br><br>**Default**: `build/tmp/kaitai-cache`                                                                                            |
+| sourceDirectory | java.io.File | 0.1.0 | Source directory with [Kaitai Struct language](http://formats.kaitai.io/) files.<br><br>**Default**: src/main/resources/kaitai                                                       |
+| includes        | String[]     | 0.1.0 | Include wildcard pattern list.<br><br>**Default**: ["*.ksy"]                                                                                                                         |
+| excludes        | String[]     | 0.1.0 | Exclude wildcard pattern list.<br><br>**Default**: []                                                                                                                                |
+| output          | java.io.File | 0.1.0 | Target directory for generated Java source files.<br><br>**Default**: `build/generated/kaitai`                                                                                       |
+| exactOutput     | Boolean      | 0.1.5 | Move root of packages directory structure exact inside configured output path and remove `src` item. Use only for 0.8 and earlier. Has no effect in 0.9+<br><br>**Default**: `false` |
+| packageName     | String       | 0.1.0 | Target package for generated Java source files.<br><br>**Default**: Trying to get project's group or `kaitai` otherwise                                                              |
+| executionTimeout| Long         | 0.1.3 | Timeout for execution operations.<br><br>**Default**: `5000`                                                                                                                         |
+| fromFileClass   | String       | 0.1.3 | Classname with custom KaitaiStream implementations for static builder `fromFile(...)`                                                                                                |
+| opaqueTypes     | Boolean      | 0.1.3 | Allow use opaque (external) types in ksy. See more in [documentation](http://doc.kaitai.io/user_guide.html#opaque-types).                                                            |
+| noVersionCheck  | Boolean      | 0.1.6 | Allow to disable Java version check. For non-Windows only.<br><br>**Default**: `false`                                                                                               |
+| noAutoRead      | Boolean      | 0.1.7 | Allow to disable auto-running `_read` in constructor <br><br>**Default**: `false`                                                                                                    |
 
 ### Useful commands
 

--- a/src/main/java/name/valery1707/kaitai/KaitaiGenerator.java
+++ b/src/main/java/name/valery1707/kaitai/KaitaiGenerator.java
@@ -356,8 +356,8 @@ public class KaitaiGenerator {
 
 		log.info("Kaitai: generate");
 		execute(builder);
-		output = output.resolve("src");
 		if (isExactOutput()) {
+			output = output.resolve("src"); // if you set this option, you are probably using 0.8 or earlier
 			Path root = getOutput();
 			List<Path> generated = scanFiles(output, new String[]{"*"}, new String[0]);
 			move(output, generated, root);

--- a/src/main/java/name/valery1707/kaitai/KaitaiMojo.java
+++ b/src/main/java/name/valery1707/kaitai/KaitaiMojo.java
@@ -31,7 +31,7 @@ import static name.valery1707.kaitai.KaitaiUtils.*;
 	, defaultPhase = LifecyclePhase.GENERATE_SOURCES
 )
 public class KaitaiMojo extends AbstractMojo {
-	static final String KAITAI_VERSION = "0.8";
+	static final String KAITAI_VERSION = "0.10";
 
 	/**
 	 * Version of <a href="http://kaitai.io/#download">KaiTai</a> library.

--- a/src/main/java/name/valery1707/kaitai/KaitaiUtils.java
+++ b/src/main/java/name/valery1707/kaitai/KaitaiUtils.java
@@ -359,7 +359,7 @@ public final class KaitaiUtils {
 		return dir;
 	}
 
-	private static final String URL_FORMAT = "https://dl.bintray.com/kaitai-io/universal/%s/kaitai-struct-compiler-%s.zip";
+	private static final String URL_FORMAT = "https://github.com/kaitai-io/kaitai_struct_compiler/releases/download/%s/kaitai-struct-compiler-%s.zip";
 
 	/**
 	 * Use external {@code url} if it non null or create new url from template.

--- a/src/test/java/name/valery1707/kaitai/KaitaiGeneratorTest.java
+++ b/src/test/java/name/valery1707/kaitai/KaitaiGeneratorTest.java
@@ -70,7 +70,7 @@ public class KaitaiGeneratorTest {
 			.resolve("it-source-exist/src/main/resources/kaitai/ico.ksy");
 		KaitaiGenerator generator = generator(source);
 		Path target = generator.generate(LOG);
-		assertThat(target).isDirectory().hasFileName("src");
+		assertThat(target).isDirectory();
 		Path pkg = target.resolve(generator.getPackageName().replace('.', '/'));
 		assertThat(pkg).isDirectory();
 		for (Path src : generator.getSources()) {
@@ -90,7 +90,7 @@ public class KaitaiGeneratorTest {
 			fail("Must generate exception because of problems in specification");
 		} catch (KaitaiException e) {
 			assertThat(e)
-				.hasMessageContaining("/types/header/seq/0/id: invalid attribute ID: 'Magic', expected /^[a-z][a-z0-9_]*$/")
+				.hasMessageContaining("/types/header/seq/0/id:\n\terror: invalid attribute ID: 'Magic', expected /^[a-z][a-z0-9_]*$/")
 			;
 			assertThat(e.getMessage()).doesNotContain(KAITAI_VERSION);
 
@@ -159,7 +159,7 @@ public class KaitaiGeneratorTest {
 		KaitaiGenerator generator = generator(source)
 			.fromFileClass(fromFileClass);
 		Path target = generator.generate(LOG);
-		assertThat(target).isDirectory().hasFileName("src");
+		assertThat(target).isDirectory();
 		Path pkg = target.resolve(generator.getPackageName().replace('.', '/'));
 		assertThat(pkg).isDirectory();
 		for (Path src : generator.getSources()) {
@@ -181,7 +181,7 @@ public class KaitaiGeneratorTest {
 		KaitaiGenerator generator = generator(source)
 			.opaqueTypes(true);
 		Path target = generator.generate(LOG);
-		assertThat(target).isDirectory().hasFileName("src");
+		assertThat(target).isDirectory();
 		Path pkg = target.resolve(generator.getPackageName().replace('.', '/'));
 		assertThat(pkg).isDirectory();
 		for (Path src : generator.getSources()) {
@@ -206,7 +206,7 @@ public class KaitaiGeneratorTest {
 			fail("Must generate exception because of problems in specification");
 		} catch (KaitaiException e) {
 			assertThat(e)
-				.hasMessageContaining("/seq/0: unable to find type 'custom_encrypted_object', searching from doc_container")
+				.hasMessageContaining("/seq/0:\n\terror: unable to find type 'custom_encrypted_object', searching from doc_container")
 			;
 			assertThat(e.getMessage()).doesNotContain(KAITAI_VERSION);
 


### PR DESCRIPTION
This is necessary for the tests to pass on the gradle plugin https://github.com/valery1707/kaitai-gradle-plugin/pull/22, and also includes the other pr #56, though I made it separate as some values may need re-thinking as they are pointless for later versions. Also due to changes may require a version bump, but that's not included here